### PR TITLE
fix: updates `.EXAMPLE` items for `Get-VCFCertificateCSR` cmdlet

### DIFF
--- a/PowerVCF.psm1
+++ b/PowerVCF.psm1
@@ -803,11 +803,11 @@ Function Get-VCFCertificateCSR {
         The Get-VCFCertificateCSR cmdlet gets the available CSRs that have been created on SDDC Manager
 
         .EXAMPLE
-        Get-VCFCertificateCSR -domainName MGMT
+        Get-VCFCertificateCSR -domainName sfo-m01
         This example gets a list of CSRs and displays the output
 
         .EXAMPLE
-        Get-VCFCertificateCSR -domainName MGMT | ConvertTo-Json
+        Get-VCFCertificateCSR -domainName sfo-m01 | ConvertTo-Json
         This example gets a list of CSRs and displays them in JSON format
     #>
 

--- a/PowerVCF.psm1
+++ b/PowerVCF.psm1
@@ -803,11 +803,11 @@ Function Get-VCFCertificateCSR {
         The Get-VCFCertificateCSR cmdlet gets the available CSRs that have been created on SDDC Manager
 
         .EXAMPLE
-        Get-VCFCertificateCSRs -domainName MGMT
+        Get-VCFCertificateCSR -domainName MGMT
         This example gets a list of CSRs and displays the output
 
         .EXAMPLE
-        Get-VCFCertificateCSRs -domainName MGMT | ConvertTo-Json
+        Get-VCFCertificateCSR -domainName MGMT | ConvertTo-Json
         This example gets a list of CSRs and displays them in JSON format
     #>
 


### PR DESCRIPTION
## Summary of Pull Request

Updates the `.EXAMPLE` items for `Get-VCFCertificateCSR` cmdlet to reflect `Get-VCFCertificateCSR` instead of `Get-VCFCertificateCSRs`.

## Type of Pull Request

- [x] This is a bugfix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style / formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [ ] This is something else.
      Please describe:

## Related to Existing Issues

Resolves #143

## Test and Documentation Coverage

- [ ] Tests have been completed (for bugfixes / features).
- [x] Documentation has been added / updated (for bugfixes / features).

## Breaking Changes?

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.
