### PR TITLE
feat: add proxy configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 - Enhanced `Get-VCFManager` cmdlet to return the SDDC Manager build in `xxxxxxx` format.
 - Added `Set-VCFCredentialAutoRotate` cmdlet to configure or disable credential auto-rotation for a credential managed by SDDC Manager.
 - Fixed `validateJsonInput` function to prevent it from truncating directly passed JSON content.
+- Added `Get-VcfProxy` cmdlet to retrieve the proxy configuration for the SDDC Manager.
+- Added `Set-VcfProxy` cmdlet to configure the proxy configuration for the SDDC Manager.
 
 ## v2.3.0
 

--- a/PowerVCF.psd1
+++ b/PowerVCF.psd1
@@ -12,7 +12,7 @@
 RootModule = 'PowerVCF.psm1'
 
 # Version number of this module.
-ModuleVersion = '2.4.0.1003'
+ModuleVersion = '2.4.0.1004'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/docs/documentation/functions/proxy/Get-VcfProxy.md
+++ b/docs/documentation/functions/proxy/Get-VcfProxy.md
@@ -1,0 +1,25 @@
+# Get-VcfProxy
+
+## Synopsis
+
+Gets the proxy configuration for the SDDC Manager.
+
+## Syntax
+
+```powershell
+Get-VcfProxy
+```
+
+## Description
+
+The `Get-VcfProxy` cmdlet retrieves the proxy configuration of the SDDC Manager.
+
+## Examples
+
+### Example 1
+
+```powershell
+Get-VcfProxy
+```
+
+This example shows how to get the proxy configuration of the SDDC Manager.

--- a/docs/documentation/functions/proxy/Set-VcfProxy.md
+++ b/docs/documentation/functions/proxy/Set-VcfProxy.md
@@ -1,0 +1,91 @@
+# Set-VcfProxy
+
+## Synopsis
+
+Sets the proxy configuration for the SDDC Manager.
+
+## Syntax
+
+```powershell
+Set-VcfProxy -status <String> [-proxyHost <String>] [-proxyPort <Int32>] [<Common Parameters>]
+```
+
+## Description
+
+The `Set-VcfProxy` cmdlet sets the proxy configuration of the SDDC Manager.
+
+???+ note
+
+    This cmdlet will not clear the proxy configuration.
+
+## Examples
+
+### Example 1
+
+```powershell
+Set-VcfProxy -status ENABLED -proxyHost proxy.rainpole.io -proxyPort 3128
+```
+
+This example shows how to enable the proxy configuration of the SDDC Manager.
+
+### Example 2
+
+```powershell
+Set-VcfProxy -status DISABLED
+```
+
+This example shows how to disable the proxy configuration of the SDDC Manager.
+
+## Parameters
+
+### -status
+
+Enable or disable the proxy configuration.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -proxyHost
+
+The fully qualified domain name or IP address of the proxy.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -proxyPort
+
+The port number of the proxy.
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: 0
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### Common Parameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_Common Parameters](http://go.microsoft.com/fwlink/?LinkID=113216).

--- a/docs/documentation/functions/releases/Get-VCFRelease.md
+++ b/docs/documentation/functions/releases/Get-VCFRelease.md
@@ -270,6 +270,6 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### CommonParameters
+### Common Parameters
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -252,6 +252,9 @@ nav:
     - documentation/functions/personalities/New-VCFPersonality.md
   - Platform Services Controllers:
     - documentation/functions/pscs/Get-VCFPSC.md
+  - Proxy:
+    - documentation/functions/proxy/Get-VcfProxy.md
+    - documentation/functions/proxy/Set-VcfProxy.md
   - Releases:
     - documentation/functions/releases/Get-VCFRelease.md
   - SDDC (Cloud Builder):

--- a/samples/proxy/proxySpec.json
+++ b/samples/proxy/proxySpec.json
@@ -1,0 +1,5 @@
+{
+    "isEnabled": true,
+    "host": "proxy.rainpole.io",
+    "port": 3128
+}


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 no-inline-html -->

<!--
    In order to have the best experience with our community, we recommend that you read the code of conduct and contributing guidelines before submitting a pull request.
    
    By submitting this pull request, you confirm that you have read, understood, and agreed to the project's code of conduct and contributing guidelines.

    Please use conventional commits to format the title of the pull request and the commit messages.
    For more information, please refer to https://www.conventionalcommits.org.
-->

### Summary

<!--
    Please provide a clear and concise description of the pull request.
-->

The API was added in VMware Cloud Foundation 4.5.0. See https://developer.vmware.com/apis/vcf/4.5.0/changelog/.

- Added `Get-VcfProxy` cmdlet to retrieve the proxy configuration for the SDDC Manager.
- Added `Set-VcfProxy` cmdlet to configure the proxy configuration for the SDDC Manager.
- Added `Get-VcfProxy` documentation.
- Added `Set-VcfProxy` documentation.
- Added JSON sample, though not needed for the cmdlet.
- Updated `CHANGELOG.md`.
- Updated module version to 2.4.0.1004.

### Type

<!--
    Please check the one(s) that applies to this pull request using "x".
-->

- [ ] Bugfix
- [x] Enhancement or Feature
- [ ] Code Style or Formatting
- [ ] Documentation
- [ ] Refactoring
- [ ] Chore
- [ ] Other
        Please describe:

### Breaking Changes?

<!--
    Please check the one that applies to this pull request using "x".
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

### Test and Documentation

<!--
    Please check the one(s) that applies to this pull request using "x".
    For bug fixes and enhancements/features, please ensure that tests and documentation have been completed and provide details.
-->

- [x] Tests have been completed.
- [x] Documentation has been added or updated.

On 4.4.x and earlier
```powershell
PS F:\PowerVCF> Set-VcfProxy -status DISABLED
Set-VcfProxy: This API is not supported on this version of VMware Cloud Foundation: 4.4.1.0.


PS F:\PowerVCF> Get-VcfProxy 
Set-VcfProxy: This API is not supported on this version of VMware Cloud Foundation: 4.4.1.0.
```

On 4.5.0 and later.

```powershell
PS F:\PowerVCF> Get-VcfProxy

isConfigured
------------
        False


PS F:\PowerVCF> Set-VcfProxy -status ENABLED -proxyHost proxy.rainpole.io -proxyPort 3128

id                  : e7f39b2c-6f81-4b05-93d2-57ba604e52e8
name                : Configure proxy server for VCF system
status              : COMPLETED_WITH_SUCCESS
creationTimestamp   : 9/5/2023 5:13:06 PM
completionTimestamp : 9/5/2023 5:13:06 PM


PS F:\PowerVCF> Get-VcfProxy

isConfigured isEnabled host             port
------------ --------- ----             ----
        True      True proxy.rainpole.io 3128


PS F:\PowerVCF> Set-VcfProxy -status ENABLED -proxyHost proxy.rainpole.io
Set-VcfProxy: The proxy host and port must be specified when enabling the proxy configuration.


PS F:\PowerVCF> Set-VcfProxy -status ENABLED -proxyPort 3128
Set-VcfProxy: The proxy host and port must be specified when enabling the proxy configuration.


PS F:\PowerVCF> Set-VcfProxy -status ENABLED -proxyHost -proxyPort
Set-VcfProxy: Missing an argument for parameter 'proxyHost'. Specify a parameter of type 'System.String' and try again.
PS F:\PowerVCF>


PS F:\PowerVCF> Set-VcfProxy -status ENABLED -proxyHost proxy.rainpole.io -proxyPort 0
Set-VcfProxy: Cannot validate argument on parameter 'proxyPort'. The 0 argument is less than the minimum allowed range of 1. Supply an argument that is greater than or equal to 1 and then try the command again.


PS F:\PowerVCF> Set-VcfProxy -status ENABLED -proxyHost proxy.rainpole.io -proxyPort 65536
Set-VcfProxy: Cannot validate argument on parameter 'proxyPort'. The 65536 argument is greater than the maximum allowed range of 65536. Supply an argument that is less than or equal to 65535 and then try the command again.


PS F:\PowerVCF> Set-VcfProxy -status ENABLED -proxyHost proxy.rainpole.io -proxyPort 8443
Set-VcfProxy: The proxy host proxy.rainpole.io is not reachable on port TCP 8443.


PS F:\PowerVCF> Set-VcfProxy -status DISABLED -proxyHost proxy.rainpole.io -proxyPort 3128
WARNING: The proxy host and port should not be specified when disabling the proxy configuration.


PS F:\PowerVCF> Set-VcfProxy -status DISABLED

id                  : bc2dcbc9-08b7-4eaf-ac9b-431ee43c9b27
name                : Configure proxy server for VCF system
status              : COMPLETED_WITH_SUCCESS
creationTimestamp   : 9/5/2023 5:17:24 PM
completionTimestamp : 9/5/2023 5:17:24 PM


PS F:\PowerVCF> Get-VcfProxy

isConfigured isEnabled host             port
------------ --------- ----             ----
        True     False proxy.rainpole.io 3128
```

<!--
    Please describe the tests that have been completed and/or the documentation that has been added/updated.
-->

### Issue References

<!--
    Is this related to any GitHub issue(s)? If so, please provide the issue number(s) that are closed or resolved by this pull request.

    For bug fixes and enhancements/features, please ensure that a GitHub issue has been created and provide the issue number(s) here.

    Please use the 'Closes' keyword followed by the a hash and issue number.
    This will link the pull request to the issue(s) and automatically close them when the pull request is merged.

    Example:

    Closes #000
    Closes #001
-->

### Additional Information

<!--
    Please provide any additional information that may be helpful.
-->
