### PR TITLE
fix: increase `Get-VCFSystemPrecheckTask` output verbosity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## v2.5.0
+
+> Released: Unreleased 
+
+- Updated `Get-VCFSystemPrecheckTask` cmdlet with optional parameter `failureOnly`.
+
 ## v2.4.1
 
 > Released: 2023-12-15

--- a/PowerVCF.psd1
+++ b/PowerVCF.psd1
@@ -11,7 +11,7 @@
 RootModule = 'PowerVCF.psm1'
 
 # Version number of this module.
-ModuleVersion = '2.4.1.1000'
+ModuleVersion = '2.5.0.1000'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/docs/documentation/functions/system-prechecks/Get-VCFSystemPrecheckTask.md
+++ b/docs/documentation/functions/system-prechecks/Get-VCFSystemPrecheckTask.md
@@ -24,6 +24,14 @@ Get-VCFSystemPrecheckTask -id 4d661acc-2be6-491d-9256-ba3c78020e5d
 
 This example shows how to retrieve the status of a system level precheck task by unique ID.
 
+### Example 2
+
+```powershell
+Get-VCFSystemPrecheckTask -id 4d661acc-2be6-491d-9256-ba3c78020e5d -failureOnly
+```
+
+This example shows how to retrieve only failed subtasks from the system level precheck task by unique ID.
+
 ## Parameters
 
 ### -id
@@ -41,7 +49,21 @@ Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
+### -failureOnly
 
+Specifies to return only the failed subtasks.
+
+```yaml
+Type: Switch
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
 ### Common Parameters
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 no-inline-html -->

<!--
    In order to have the best experience with our community, we recommend that you read the code of conduct and contributing guidelines before submitting a pull request.
    
    By submitting this pull request, you confirm that you have read, understood, and agreed to the project's code of conduct and contributing guidelines.

    Please use conventional commits to format the title of the pull request and the commit messages.
    For more information, please refer to https://www.conventionalcommits.org.
-->

### Summary

I've added "failureOnly" as an optional parameter to avoid breaking existing dependencies

Per @tenthirtyam 's request -- I've added a while loop to keep checking the pre-check task until it exits in-progress.  This applies to all invocations (not just ones with `-failureOnly`)

**Testing notes:**

```console
Remove-Module PowerVCF          
Import-Module ./PowerVCF.psm1 -Force
```
1. VCF 4.5.2 with one failed pre-check task (showing current behavior)

```console
> Get-VCFSystemPrecheckTask -id 1a25e644-3258-4d22-9cbf-ba58f92623d1  
```
```powershell
id                  : 1a25e644-3258-4d22-9cbf-ba58f92623d1
name                : PRECHECK
type                : PRECHECK
status              : FAILED
creationTimestamp   : 1/2/2024 12:34:48 PM
completionTimestamp : 1/2/2024 12:37:18 PM
subTasks            : {@{name=Upgrade - CLUSTER ; description=Upgrade - CLUSTER ; status=SUCCESSFUL; creationTimestamp=1/2/2024 12:34:48 PM; completionTimestamp=1/2/2024 12:34:50 PM; stages=System.Object[]; 
                      resources=System.Object[]}, @{name=Upgrade - DEPLOYMENT_CONFIGURATION ; description=Upgrade - DEPLOYMENT_CONFIGURATION ; status=FAILED; creationTimestamp=1/2/2024 12:34:49 PM; 
                      completionTimestamp=1/2/2024 12:35:23 PM; stages=System.Object[]; resources=System.Object[]}, @{name=Upgrade - COMMON_SERVICES ; description=Upgrade - COMMON_SERVICES ; status=SUCCESSFUL; 
                      creationTimestamp=1/2/2024 12:35:23 PM; completionTimestamp=1/2/2024 12:35:26 PM; stages=System.Object[]; resources=System.Object[]}, @{name=Upgrade - OPERATIONS_MANAGER ; description=Upgrade - 
                      OPERATIONS_MANAGER ; status=SUCCESSFUL; creationTimestamp=1/2/2024 12:34:49 PM; completionTimestamp=1/2/2024 12:34:49 PM; stages=System.Object[]; resources=System.Object[]}…}
isCancellable       : False
```

2. VCF 4.5.2 with one failed pre-check task (exercising new option -- failed only output)
```console
> Get-VCFSystemPrecheckTask -id 1a25e644-3258-4d22-9cbf-ba58f92623d1 -failureOnly
```
```powershell
VCF System Precheck complete. Overall Status: FAILED

name                : SDDC_MANAGER_FILE_PERMISSIONS_CHECK
description         : Perform Stage - Checks permissions of files and directories used by SDDC Manager services.
status              : FAILED
creationTimestamp   : 1/2/2024 12:34:49 PM
completionTimestamp : 1/2/2024 12:34:51 PM
errors              : {}
```

3. VCF 5.0.0 with pre-check running (showing current behavior)
```console
> Get-VCFSystemPrecheckTask -id 5cb59bbc-4e4d-44db-9d62-d37f7bdaf684
```             
```powershell
id                : 5cb59bbc-4e4d-44db-9d62-d37f7bdaf684
name              : PRECHECK
type              : PRECHECK
status            : IN_PROGRESS
creationTimestamp : 1/2/2024 1:12:02 PM
subTasks          : {@{name=Upgrade - CLUSTER ; description=Upgrade - CLUSTER ; status=SUCCESSFUL; creationTimestamp=1/2/2024 1:12:02 PM; completionTimestamp=1/2/2024 1:12:04 PM; stages=System.Object[]; resources=System.Object[]}, @{name=Upgrade - 
                    DEPLOYMENT_CONFIGURATION ; description=Upgrade - DEPLOYMENT_CONFIGURATION ; status=FAILED; creationTimestamp=1/2/2024 1:12:02 PM; completionTimestamp=1/2/2024 1:12:45 PM; stages=System.Object[]; resources=System.Object[]}, 
                    @{name=Upgrade - COMMON_SERVICES ; description=Upgrade - COMMON_SERVICES ; status=SUCCESSFUL; creationTimestamp=1/2/2024 1:12:45 PM; completionTimestamp=1/2/2024 1:12:48 PM; stages=System.Object[]; resources=System.Object[]}, 
                    @{name=Upgrade - OPERATIONS_MANAGER ; description=Upgrade - OPERATIONS_MANAGER ; status=SUCCESSFUL; creationTimestamp=1/2/2024 1:12:02 PM; completionTimestamp=1/2/2024 1:12:02 PM; stages=System.Object[]; 
                    resources=System.Object[]}…}
isCancellable     : False
```
4. VCF 5.0.0 with pre-check complete (showing current behavior)
```console
> Get-VCFSystemPrecheckTask -id 5cb59bbc-4e4d-44db-9d62-d37f7bdaf684            
``` 
```powershell
id                  : 5cb59bbc-4e4d-44db-9d62-d37f7bdaf684
name                : PRECHECK
type                : PRECHECK
status              : FAILED
creationTimestamp   : 1/2/2024 1:12:02 PM
completionTimestamp : 1/2/2024 1:14:24 PM
subTasks            : {@{name=Upgrade - CLUSTER ; description=Upgrade - CLUSTER ; status=SUCCESSFUL; creationTimestamp=1/2/2024 1:12:02 PM; completionTimestamp=1/2/2024 1:12:04 PM; stages=System.Object[]; resources=System.Object[]}, @{name=Upgrade - 
                      DEPLOYMENT_CONFIGURATION ; description=Upgrade - DEPLOYMENT_CONFIGURATION ; status=FAILED; creationTimestamp=1/2/2024 1:12:02 PM; completionTimestamp=1/2/2024 1:12:45 PM; stages=System.Object[]; resources=System.Object[]}, 
                      @{name=Upgrade - COMMON_SERVICES ; description=Upgrade - COMMON_SERVICES ; status=SUCCESSFUL; creationTimestamp=1/2/2024 1:12:45 PM; completionTimestamp=1/2/2024 1:12:48 PM; stages=System.Object[]; resources=System.Object[]}, 
                      @{name=Upgrade - OPERATIONS_MANAGER ; description=Upgrade - OPERATIONS_MANAGER ; status=SUCCESSFUL; creationTimestamp=1/2/2024 1:12:02 PM; completionTimestamp=1/2/2024 1:12:02 PM; stages=System.Object[]; 
                      resources=System.Object[]}…}
isCancellable       : False
```
5. VCF 5.0.0 with pre-check still running and two failures thus far (exercising new option -- failed only output)
```console
> Get-VCFSystemPrecheckTask -id 5cb59bbc-4e4d-44db-9d62-d37f7bdaf684 -failureOnly          
```                         
```powershell
VCF System Precheck still in progress. Please re-run to see the complete results

name                : Network - vMotion: Basic (unicast) connectivity check
description         : Perform Stage - Network - vMotion: Basic (unicast) connectivity check
status              : FAILED
creationTimestamp   : 1/2/2024 1:12:04 PM
completionTimestamp : 1/2/2024 1:12:04 PM
errors              : {}

name                : Network - vMotion: MTU check (ping with large packet size)
description         : Perform Stage - Network - vMotion: MTU check (ping with large packet size)
status              : FAILED
creationTimestamp   : 1/2/2024 1:12:04 PM
completionTimestamp : 1/2/2024 1:12:04 PM
errors              : {}
```

6. VCF 5.0.0 with pre-check complete and multiple failures (exercising new option -- failed only output)
```console
> Get-VCFSystemPrecheckTask -id 5cb59bbc-4e4d-44db-9d62-d37f7bdaf684 -failureOnly                                   
```
```powershell
VCF System Precheck complete. Overall Status: FAILED

name                : SDDC_MANAGER_FILE_PERMISSIONS_CHECK
description         : Perform Stage - Checks permissions of files and directories used by SDDC Manager services.
status              : FAILED
creationTimestamp   : 1/2/2024 1:12:44 PM
completionTimestamp : 1/2/2024 1:12:45 PM
errors              : {}

name                : LCM_MANIFEST_OUT_OF_DATE_CHECK
description         : Perform Stage - Checks if LCM manifest is out of date.
status              : FAILED
creationTimestamp   : 1/2/2024 1:12:49 PM
completionTimestamp : 1/2/2024 1:12:49 PM
errors              : {}

name                : Network - vMotion: Basic (unicast) connectivity check
description         : Perform Stage - Network - vMotion: Basic (unicast) connectivity check
status              : FAILED
creationTimestamp   : 1/2/2024 1:12:04 PM
completionTimestamp : 1/2/2024 1:12:04 PM
errors              : {}

name                : Network - vMotion: MTU check (ping with large packet size)
description         : Perform Stage - Network - vMotion: MTU check (ping with large packet size)
status              : FAILED
creationTimestamp   : 1/2/2024 1:12:04 PM
completionTimestamp : 1/2/2024 1:12:04 PM
errors              : {}
```

6. VCF 5.0.0 with pre-check complete with no failures (showing current behavior)
```console
> Get-VCFSystemPrecheckTask -id 5cb59bbc-4e4d-44db-9d62-d37f7bdaf684
```
```powershell
id                  : 5cb59bbc-4e4d-44db-9d62-d37f7bdaf684
name                : PRECHECK
type                : PRECHECK
status              : SUCCESSFUL
creationTimestamp   : 1/2/2024 1:12:02 PM
completionTimestamp : 1/2/2024 1:14:24 PM
subTasks            : {@{name=Upgrade - CLUSTER ; description=Upgrade - CLUSTER ; status=SUCCESSFUL; creationTimestamp=1/2/2024 1:12:02 PM; completionTimestamp=1/2/2024 1:12:04 PM; stages=System.Object[]; resources=System.Object[]}, @{name=Upgrade - 
                      DEPLOYMENT_CONFIGURATION ; description=Upgrade - DEPLOYMENT_CONFIGURATION ; status=SUCCESSFUL; creationTimestamp=1/2/2024 1:12:02 PM; completionTimestamp=1/2/2024 1:12:45 PM; stages=System.Object[]; resources=System.Object[]}, 
                      @{name=Upgrade - COMMON_SERVICES ; description=Upgrade - COMMON_SERVICES ; status=SUCCESSFUL; creationTimestamp=1/2/2024 1:12:45 PM; completionTimestamp=1/2/2024 1:12:48 PM; stages=System.Object[]; resources=System.Object[]}, 
                      @{name=Upgrade - OPERATIONS_MANAGER ; description=Upgrade - OPERATIONS_MANAGER ; status=SUCCESSFUL; creationTimestamp=1/2/2024 1:12:02 PM; completionTimestamp=1/2/2024 1:12:02 PM; stages=System.Object[]; 
                      resources=System.Object[]}…}
isCancellable       : False
```
7. VCF 5.0.0 with pre-check complete with no failures (exercising new option -- failed only output)
```console
> Get-VCFSystemPrecheckTask -id 5cb59bbc-4e4d-44db-9d62-d37f7bdaf684 -failureOnly
```
```powershell
id                  : 5cb59bbc-4e4d-44db-9d62-d37f7bdaf684
name                : PRECHECK
type                : PRECHECK
status              : SUCCESSFUL
creationTimestamp   : 1/2/2024 1:12:02 PM
completionTimestamp : 1/2/2024 1:14:24 PM
subTasks            : {@{name=Upgrade - CLUSTER ; description=Upgrade - CLUSTER ; status=SUCCESSFUL; creationTimestamp=1/2/2024 1:12:02 PM; completionTimestamp=1/2/2024 1:12:04 PM; stages=System.Object[]; resources=System.Object[]}, @{name=Upgrade - 
                      DEPLOYMENT_CONFIGURATION ; description=Upgrade - DEPLOYMENT_CONFIGURATION ; status=SUCCESSFUL; creationTimestamp=1/2/2024 1:12:02 PM; completionTimestamp=1/2/2024 1:12:45 PM; stages=System.Object[]; resources=System.Object[]}, 
                      @{name=Upgrade - COMMON_SERVICES ; description=Upgrade - COMMON_SERVICES ; status=SUCCESSFUL; creationTimestamp=1/2/2024 1:12:45 PM; completionTimestamp=1/2/2024 1:12:48 PM; stages=System.Object[]; resources=System.Object[]}, 
                      @{name=Upgrade - OPERATIONS_MANAGER ; description=Upgrade - OPERATIONS_MANAGER ; status=SUCCESSFUL; creationTimestamp=1/2/2024 1:12:02 PM; completionTimestamp=1/2/2024 1:12:02 PM; stages=System.Object[]; 
                      resources=System.Object[]}…}
isCancellable       : False
```

### Type

<!--
    Please check the one(s) that applies to this pull request using "x".
-->

- [ ] Bugfix
- [x] Enhancement or Feature
- [ ] Code Style or Formatting
- [ ] Documentation
- [ ] Refactoring
- [ ] Chore
- [ ] Other
        Please describe:

### Breaking Changes?

<!--
    Please check the one that applies to this pull request using "x".
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

### Test and Documentation

<!--
    Please check the one(s) that applies to this pull request using "x".
    For bug fixes and enhancements/features, please ensure that tests and documentation have been completed and provide details.
-->

- [x] Tests have been completed.
- [x] Documentation has been added or updated.

<!--
    Please describe the tests that have been completed and/or the documentation that has been added/updated.
-->

### Issue References

<!--
    Is this related to any GitHub issue(s)? If so, please provide the issue number(s) that are closed or resolved by this pull request.

    For bug fixes and enhancements/features, please ensure that a GitHub issue has been created and provide the issue number(s) here.

    Please use the 'Closes' keyword followed by the a hash and issue number.
    This will link the pull request to the issue(s) and automatically close them when the pull request is merged.

    Example:

    Closes #000
    Closes #001
-->

Closes #255

### Additional Information

<!--
    Please provide any additional information that may be helpful.
-->
