### PR TITLE
feat: add `name` param to `Get-VCFPersonality`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 > Released: Unreleased 
 
 - Updated `Get-VCFSystemPrecheckTask` cmdlet with optional parameter `failureOnly`.
+- Updated `Get-VCFPersonality` cmdlet with optional parameter `name`.
+
 
 ## v2.4.1
 

--- a/PowerVCF.psd1
+++ b/PowerVCF.psd1
@@ -11,7 +11,7 @@
 RootModule = 'PowerVCF.psm1'
 
 # Version number of this module.
-ModuleVersion = '2.5.0.1000'
+ModuleVersion = '2.5.0.1001'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/PowerVCF.psm1
+++ b/PowerVCF.psm1
@@ -3265,18 +3265,24 @@ Function Get-VCFPersonality {
         Get-VCFPersonality -id b4e3b2c4-31e8-4816-b1c5-801e848bef09
         This example shows how to retrieve a vSphere Lifecycle Manager personality by unique ID.
 
+        .EXAMPLE
+        Get-VCFPersonality -name vSphere-8.0U1
+        This example shows how to retrieve a vSphere Lifecycle Manager personality by name.
+
         .PARAMETER id
         Specifies the unique ID of the vSphere Lifecycle Manager personality.
     #>
 
     Param (
-        [Parameter (Mandatory = $false)] [ValidateNotNullOrEmpty()] [String]$id
+        [Parameter (Mandatory = $false)] [ValidateNotNullOrEmpty()] [String]$id,
+        [Parameter (Mandatory = $false)] [ValidateNotNullOrEmpty()] [String]$name
     )
 
     Try {
         createHeader # Set the Accept and Authorization headers.
         checkVCFToken # Validate the access token and refresh, if necessary.
-        if ( -not $PsBoundParameters.ContainsKey("id")) {
+
+        if ((-Not $PsBoundParameters.ContainsKey('id')) -and (-Not $PsBoundParameters.ContainsKey('name'))) {
             $uri = "https://$sddcManager/v1/personalities"
             $response = Invoke-RestMethod -Method GET -Uri $uri -Headers $headers
             $response.elements
@@ -3285,7 +3291,18 @@ Function Get-VCFPersonality {
             $uri = "https://$sddcManager/v1/personalities/$id"
             $response = Invoke-RestMethod -Method GET -Uri $uri -Headers $headers
             $response
-        }
+        }    
+       if  ($PsBoundParameters.ContainsKey("name")) {
+            $uri ="https://$sddcManager/v1/personalities?personalityName=$name"
+            $response = Invoke-RestMethod -Method GET -Uri $uri -Headers $headers
+            # depending on the composition of the image, the response body may or may not contain elements
+            if (!$response.elements) {
+                $response
+            } else {
+                $response.elements
+            }     
+       }    
+ 
     } Catch {
         ResponseException -object $_
     }

--- a/docs/documentation/functions/personalities/Get-VCFPersonality.md
+++ b/docs/documentation/functions/personalities/Get-VCFPersonality.md
@@ -7,7 +7,7 @@ Retrieves the vSphere Lifecycle Manager personalities.
 ## Syntax
 
 ```powershell
-Get-VCFPersonality [[-id] <String>] [<CommonParameters>]
+Get-VCFPersonality [[-id] <String>] [[-name] <String>] [<CommonParameters>]
 ```
 
 ## Description
@@ -32,6 +32,15 @@ Get-VCFPersonality -id b4e3b2c4-31e8-4816-b1c5-801e848bef09
 
 This example shows how to retrieve a vSphere Lifecycle Manager personality by unique ID.
 
+### Example 3
+
+```powershell
+Get-VCFPersonality -name vSphere-8.0U1
+```
+
+This example shows how to retrieve a vSphere Lifecycle Manager personality by unique name.
+
+
 ## Parameters
 
 ### -id
@@ -45,6 +54,22 @@ Aliases:
 
 Required: False
 Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -name
+
+Specifies the unique name of the vSphere Lifecycle Manager personality.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 2
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 no-inline-html -->

<!--
    In order to have the best experience with our community, we recommend that you read the code of conduct and contributing guidelines before submitting a pull request.
    
    By submitting this pull request, you confirm that you have read, understood, and agreed to the project's code of conduct and contributing guidelines.

    Please use conventional commits to format the title of the pull request and the commit messages.
    For more information, please refer to https://www.conventionalcommits.org.
-->

### Summary

Currently, the cmdlet `Get-VCFPersonality` displays all Personalities, or filters based on ID.  If a user has only the  `personalityName` (the only breadcrumb in the UI), they should be able to look up additional details on the image.

### Type

<!--
    Please check the one(s) that applies to this pull request using "x".
-->

- [ ] Bugfix
- [X] Enhancement or Feature
- [ ] Code Style or Formatting
- [ ] Documentation
- [ ] Refactoring
- [ ] Chore
- [ ] Other
        Please describe:

### Breaking Changes?

- [ ] Yes, there are breaking changes.
- [X] No, there are no breaking changes.

### Test and Documentation

- [X] Tests have been completed.
- [X] Documentation has been added or updated.

The new optional parameter has been tested against images w/o and without components, on both VCF 4.5 and VCF 5.1.  

Output on VCF 5.1

New parameter:

```powershell
> Get-VCFPersonality -name second-image

version                 : 1
personalityId           : c11cce2c-81c5-488a-aa9c-189b2ec4f5cd
personalityName         : second-image
vsphereExportedZipPath  : https://sfo-vcf01.sfo.rainpole.io/vmware/vcf/personalities/c11cce2c-81c5-488a-aa9c-189b2ec4f5cd/Content/OFFLINE_BUNDLE_522c1f83-c4f6-8d62-eb69-6d8087585b0f.zip
vsphereExportedIsoPath  : https://sfo-vcf01.sfo.rainpole.io/vmware/vcf/personalities/c11cce2c-81c5-488a-aa9c-189b2ec4f5cd/Content/ISO_IMAGE_522c1f83-c4f6-8d62-eb69-6d8087585b0f.iso
vsphereExportedJsonPath : https://sfo-vcf01.sfo.rainpole.io/vmware/vcf/personalities/c11cce2c-81c5-488a-aa9c-189b2ec4f5cd/Content/SOFTWARE_SPEC_522c1f83-c4f6-8d62-eb69-6d8087585b0f.json
importTimestamp         : 1/10/2024 2:31:29 PM
softwareInfo            : @{baseImage=; components=}

```

Verified existing behavior:

```powershell
> Get-VCFPersonality -id c11cce2c-81c5-488a-aa9c-189b2ec4f5cd

version                 : 1
personalityId           : c11cce2c-81c5-488a-aa9c-189b2ec4f5cd
personalityName         : second-image
vsphereExportedZipPath  : https://sfo-vcf01.sfo.rainpole.io/vmware/vcf/personalities/c11cce2c-81c5-488a-aa9c-189b2ec4f5cd/Content/OFFLINE_BUNDLE_522c1f83-c4f6-8d62-eb69-6d8087585b0f.zip
vsphereExportedIsoPath  : https://sfo-vcf01.sfo.rainpole.io/vmware/vcf/personalities/c11cce2c-81c5-488a-aa9c-189b2ec4f5cd/Content/ISO_IMAGE_522c1f83-c4f6-8d62-eb69-6d8087585b0f.iso
vsphereExportedJsonPath : https://sfo-vcf01.sfo.rainpole.io/vmware/vcf/personalities/c11cce2c-81c5-488a-aa9c-189b2ec4f5cd/Content/SOFTWARE_SPEC_522c1f83-c4f6-8d62-eb69-6d8087585b0f.json
importTimestamp         : 1/10/2024 2:31:29 PM
softwareInfo            : @{baseImage=; components=}

> Get-VCFPersonality 

version                 : 1
personalityId           : 9c392ec1-acf1-488e-9641-c076a37434a1
personalityName         : sfo-sd01-cl01-vSphere-8.0U1
vsphereExportedZipPath  : https://sfo-vcf01.sfo.rainpole.io/vmware/vcf/personalities/9c392ec1-acf1-488e-9641-c076a37434a1/Content/OFFLINE_BUNDLE_52636528-246b-c692-9dcd-0550572268ff.zip
vsphereExportedIsoPath  : https://sfo-vcf01.sfo.rainpole.io/vmware/vcf/personalities/9c392ec1-acf1-488e-9641-c076a37434a1/Content/ISO_IMAGE_52636528-246b-c692-9dcd-0550572268ff.iso
vsphereExportedJsonPath : https://sfo-vcf01.sfo.rainpole.io/vmware/vcf/personalities/9c392ec1-acf1-488e-9641-c076a37434a1/Content/SOFTWARE_SPEC_52636528-246b-c692-9dcd-0550572268ff.json
importTimestamp         : 1/9/2024 8:09:29 PM
softwareInfo            : @{baseImage=; components=}

version                 : 1
personalityId           : c11cce2c-81c5-488a-aa9c-189b2ec4f5cd
personalityName         : second-image
vsphereExportedZipPath  : https://sfo-vcf01.sfo.rainpole.io/vmware/vcf/personalities/c11cce2c-81c5-488a-aa9c-189b2ec4f5cd/Content/OFFLINE_BUNDLE_522c1f83-c4f6-8d62-eb69-6d8087585b0f.zip
vsphereExportedIsoPath  : https://sfo-vcf01.sfo.rainpole.io/vmware/vcf/personalities/c11cce2c-81c5-488a-aa9c-189b2ec4f5cd/Content/ISO_IMAGE_522c1f83-c4f6-8d62-eb69-6d8087585b0f.iso
vsphereExportedJsonPath : https://sfo-vcf01.sfo.rainpole.io/vmware/vcf/personalities/c11cce2c-81c5-488a-aa9c-189b2ec4f5cd/Content/SOFTWARE_SPEC_522c1f83-c4f6-8d62-eb69-6d8087585b0f.json
importTimestamp         : 1/10/2024 2:31:29 PM
softwareInfo            : @{baseImage=; components=}

```

Output on VCF 4.5

New parameter:

```powershell
> Get-VCFPersonality -name second-image                        

version                 : 1
personalityId           : 628554c5-a88b-455d-b0f1-63c9383a53ac
personalityName         : second-image
releaseDate             : 1704906589683
vsphereExportedZipPath  : https://sddc-manager.vrack.vsphere.local/vmware/vcf/personalities/628554c5-a88b-455d-b0f1-63c9383a53ac/Content/OFFLINE_BUNDLE_1487770264.zip
vsphereExportedIsoPath  : https://sddc-manager.vrack.vsphere.local/vmware/vcf/personalities/628554c5-a88b-455d-b0f1-63c9383a53ac/Content/ISO_IMAGE_1487770264.iso
vsphereExportedJsonPath : https://sddc-manager.vrack.vsphere.local/vmware/vcf/personalities/628554c5-a88b-455d-b0f1-63c9383a53ac/Content/SOFTWARE_SPEC_1487770264.json
softwareInfo            : @{baseImage=; components=}
```

Verified existing behavior:

```powershell
> Get-VCFPersonality -id 628554c5-a88b-455d-b0f1-63c9383a53ac

version                 : 1
personalityId           : 628554c5-a88b-455d-b0f1-63c9383a53ac
personalityName         : second-image
releaseDate             : 1704906589683
vsphereExportedZipPath  : https://sddc-manager.vrack.vsphere.local/vmware/vcf/personalities/628554c5-a88b-455d-b0f1-63c9383a53ac/Content/OFFLINE_BUNDLE_1487770264.zip
vsphereExportedIsoPath  : https://sddc-manager.vrack.vsphere.local/vmware/vcf/personalities/628554c5-a88b-455d-b0f1-63c9383a53ac/Content/ISO_IMAGE_1487770264.iso
vsphereExportedJsonPath : https://sddc-manager.vrack.vsphere.local/vmware/vcf/personalities/628554c5-a88b-455d-b0f1-63c9383a53ac/Content/SOFTWARE_SPEC_1487770264.json
softwareInfo            : @{baseImage=; components=}

> Get-VCFPersonality 

version                 : 1
personalityId           : e092ed90-d136-43f2-b27e-5d86970d2ed9
personalityName         : SDDC-Cluster1-vSphere-7.0U3
releaseDate             : 1704906522264
vsphereExportedZipPath  : https://sddc-manager.vrack.vsphere.local/vmware/vcf/personalities/e092ed90-d136-43f2-b27e-5d86970d2ed9/Content/OFFLINE_BUNDLE_2078720658.zip
vsphereExportedIsoPath  : https://sddc-manager.vrack.vsphere.local/vmware/vcf/personalities/e092ed90-d136-43f2-b27e-5d86970d2ed9/Content/ISO_IMAGE_2078720658.iso
vsphereExportedJsonPath : https://sddc-manager.vrack.vsphere.local/vmware/vcf/personalities/e092ed90-d136-43f2-b27e-5d86970d2ed9/Content/SOFTWARE_SPEC_2078720658.json
softwareInfo            : @{baseImage=; components=}

version                 : 1
personalityId           : 628554c5-a88b-455d-b0f1-63c9383a53ac
personalityName         : second-image
releaseDate             : 1704906589683
vsphereExportedZipPath  : https://sddc-manager.vrack.vsphere.local/vmware/vcf/personalities/628554c5-a88b-455d-b0f1-63c9383a53ac/Content/OFFLINE_BUNDLE_1487770264.zip
vsphereExportedIsoPath  : https://sddc-manager.vrack.vsphere.local/vmware/vcf/personalities/628554c5-a88b-455d-b0f1-63c9383a53ac/Content/ISO_IMAGE_1487770264.iso
vsphereExportedJsonPath : https://sddc-manager.vrack.vsphere.local/vmware/vcf/personalities/628554c5-a88b-455d-b0f1-63c9383a53ac/Content/SOFTWARE_SPEC_1487770264.json
softwareInfo            : @{baseImage=; components=}
```

