### PR TITLE
feat: add pscredential and securestring

### DIFF
--- a/PowerVCF.psd1
+++ b/PowerVCF.psd1
@@ -11,7 +11,7 @@
     RootModule        = 'PowerVCF.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '2.5.0.1015'
+    ModuleVersion     = '2.5.0.1016'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/docs/documentation/functions/authentication/Connect-CloudBuilder.md
+++ b/docs/documentation/functions/authentication/Connect-CloudBuilder.md
@@ -7,7 +7,7 @@ Requests an authentication token from a VMware Cloud Builder instance.
 ## Syntax
 
 ```powershell
-Connect-CloudBuilder [-fqdn] <String> [[-username] <String>] [[-password] <String>] [-skipCertificateCheck] [<CommonParameters>]
+Connect-CloudBuilder [-fqdn] <String> [[-username] <String>] [[-password] <String>] [[-credential] <PSCredential>] [-skipCertificateCheck] [<CommonParameters>]
 ```
 
 ## Description
@@ -23,10 +23,44 @@ The `Connect-CloudBuilder` cmdlet connects to the specified VMware Cloud Builder
 ### Example 1
 
 ```powershell
-Connect-CloudBuilder -fqdn sfo-cb01.sfo.rainpole.io -username admin -password VMware1!
+Connect-CloudBuilder -fqdn sfo-cb01.sfo.rainpole.io -username admin -password VMw@re1!
 ```
 
-This example shows how to connect to the VMware Cloud Builder instance.
+This example shows how to connect to the specified VMware Cloud Builder instance using a clear-text username and password.
+
+### Example 2
+
+```powershell
+$secureString = Read-Host -AsSecureString 'Password'
+Connect-CloudBuilder -fqdn sfo-cb01.sfo.rainpole.io -username admin -password $secureString
+```
+
+This example shows how to connect to the specified VMware Cloud Builder instance using a `SecureString` password.
+
+### Example 3
+
+```powershell
+$credential = Get-Credential
+Connect-CloudBuilder -fqdn sfo-cb01.sfo.rainpole.io -credential $credential
+```
+
+This example shows how to connect to the specified VMware Cloud Builder instance using a PSCredential.
+
+### Example 4
+
+```powershell
+Connect-CloudBuilder -fqdn sfo-cb01.sfo.rainpole.io -username admin
+```
+
+This example shows how to connect to the specified VMware Cloud Builder instance where the user will be prompted for a password.
+
+### Example 5
+
+```powershell
+Connect-CloudBuilder -fqdn sfo-cb01.sfo.rainpole.io
+```
+
+This example shows how to connect to the specified VMware Cloud Builder instance where the user will be prompted for a username and password.
 
 ## Parameters
 
@@ -36,7 +70,7 @@ The fully qualified domain name of the VMware Cloud Builder instance.
 
 ```yaml
 Type: String
-Parameter Sets: (All)
+Parameter Sets: PSCredentialSet, UserNameAndPasswordSet
 Aliases:
 
 Required: True
@@ -52,10 +86,10 @@ The username to authenticate to the VMware Cloud Builder instance.
 
 ```yaml
 Type: String
-Parameter Sets: (All)
+Parameter Sets: UserNameAndPasswordSet
 Aliases:
 
-Required: False
+Required: True
 Position: 2
 Default value: None
 Accept pipeline input: False
@@ -64,15 +98,33 @@ Accept wildcard characters: False
 
 ### -password
 
-The password to authenticate to the VMware Cloud Builder instance.
+The password to authenticate to the VMware Cloud Builder instance. This parameter takes either a string or a `SecureString` value.
+
+If not specified, the user will be prompted for the `SecureString` value.
 
 ```yaml
 Type: String
-Parameter Sets: (All)
+Parameter Sets: UserNameAndPasswordSet
 Aliases:
 
 Required: False
 Position: 3
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -credential
+
+Specifies to authenticate to the SDDC Manager instance using a PSCredential object.
+
+```yaml
+Type: PSCredential
+Parameter Sets: PSCredentialSet
+Aliases:
+
+Required: True
+Position: 4
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/documentation/functions/authentication/Request-VCFToken.md
+++ b/docs/documentation/functions/authentication/Request-VCFToken.md
@@ -7,7 +7,7 @@ Requests an authentication token from SDDC Manager.
 ## Syntax
 
 ```powershell
-Request-VCFToken [-fqdn] <String> [[-username] <String>] [[-password] <String>] [-skipCertificateCheck] [<CommonParameters>]
+Request-VCFToken [-fqdn] <String> [[-username] <String>] [[-password] <String>] [[-credential] <PSCredential>] [-skipCertificateCheck] [<CommonParameters>]
 ```
 
 ## Description
@@ -22,15 +22,41 @@ The `Request-VCFToken` cmdlet connects to the specified SDDC Manager and request
 Request-VCFToken -fqdn sfo-vcf01.sfo.rainpole.io -username administrator@vsphere.local -password VMw@re1!
 ```
 
-This example shows how to connect to SDDC Manager to request API access and refresh tokens.
+This example shows how to connect to the specified SDDC Manager using a clear-text username and password.
 
 ### Example 2
 
 ```powershell
-Request-VCFToken -fqdn sfo-vcf01.sfo.rainpole.io -username admin@local -password VMw@re1!VMw@re1!
+$secureString = Read-Host -AsSecureString 'Password'
+Request-VCFToken -fqdn sfo-vcf01.sfo.rainpole.io -username admin@local -password $secureString
 ```
 
-This example shows how to connect to SDDC Manager using local account `admin@local`.
+This example shows how to connect to the specified SDDC Manager instance using a `SecureString` password.
+
+### Example 3
+
+```powershell
+$credential = Get-Credential
+Request-VCFToken -fqdn sfo-vcf01.sfo.rainpole.io -credential $credential
+```
+
+This example shows how to connect to the specified SDDC Manager instance using a PSCredential.
+
+### Example 4
+
+```powershell
+Request-VCFToken -fqdn sfo-vcf01.sfo.rainpole.io -username admin@local
+```
+
+This example shows how to connect to the SDDC Manager instance where the user will be prompted for a password.
+
+### Example 5
+
+```powershell
+Request-VCFToken -fqdn sfo-vcf01.sfo.rainpole.io
+```
+
+This example shows how to connect to the specified SDDC Manager instance where the user will be prompted for a username and password.
 
 ## Parameters
 
@@ -40,7 +66,7 @@ The fully qualified domain name or IP Address of the SDDC Manager instance.
 
 ```yaml
 Type: String
-Parameter Sets: (All)
+Parameter Sets: PSCredentialSet, UserNameAndPasswordSet
 Aliases:
 
 Required: True
@@ -56,10 +82,10 @@ The username to authenticate to the SDDC Manager instance.
 
 ```yaml
 Type: String
-Parameter Sets: (All)
+Parameter Sets: UserNameAndPasswordSet
 Aliases:
 
-Required: False
+Required: True
 Position: 2
 Default value: None
 Accept pipeline input: False
@@ -68,15 +94,33 @@ Accept wildcard characters: False
 
 ### -password
 
-The password to authenticate to the SDDC Manager instance.
+The password to authenticate to the SDDC Manager instance. This parameter takes either a string or a `SecureString` value.
+
+If not specified, the user will be prompted for the `SecureString` value.
 
 ```yaml
 Type: String
-Parameter Sets: (All)
+Parameter Sets: UserNameAndPasswordSet
 Aliases:
 
 Required: False
 Position: 3
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -credential
+
+Specifies to authenticate to the SDDC Manager instance using a PSCredential object.
+
+```yaml
+Type: PSCredential
+Parameter Sets: PSCredentialSet
+Aliases:
+
+Required: True
+Position: 4
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False


### PR DESCRIPTION
### Summary

Enhanced Request-VCFToken and Connect-CloudBuilder by adding a PSCredential parameter set and adding support for SecureString for the Password parameter.

I've tested the following:

#### SDDC Manager

1. Use a clear-text string password.

```powershell
Request-VCFToken -fqdn <fqdn> -username administrator@vsphere.local -password <plainTextPassword>
```

2. Use a `SecureString` password.


```powershell
$secureString = Read-Host -AsSecureString 'Password'
Request-VCFToken -fqdn <fqdn> -username administrator@vsphere.local -password $secureString
```

3. Use a `SecureString` as password.


```powershell
Request-VCFToken -fqdn <fqdn> -username administrator@vsphere.local
```

4. Use a `PSCredential` object.

```powershell
$credential = Get-Credential
Request-VCFToken -fqdn <fqdn> -credential $credential
```

5. Provide a `PSCredential` object (username/password).

```powershell
Request-VCFToken -fqdn <fqdn>
```

#### Cloud Builder

1. Use a clear-text string password.

```powershell
Connect-CloudBuilder -fqdn <fqdn> -username admin -password <plainTextPassword>
```

2. Use a `SecureString` password.

```powershell
$secureString = Read-Host -AsSecureString 'Password'
Connect-CloudBuilder -fqdn <fqdn> -username admin -password $secureString
```

3. Use a `SecureString` as password.

```powershell
Connect-CloudBuilder -fqdn <fqdn> -username admin
```

4. Use a `PSCredential` object.

```powershell
$credential = Get-Credential
Connect-CloudBuilder -fqdn <fqdn> -credential $credential
```

5. Provide a `PSCredential` object (username/password).


```powershell
Connect-CloudBuilder -fqdn <fqdn>
```

Will ask for a PSCredential (username/password).

### Type

- [ ] Bugfix
- [x] Enhancement or Feature
- [ ] Code Style or Formatting
- [x] Documentation
- [ ] Refactoring
- [ ] Chore
- [ ] Other
        Please describe:

### Breaking Changes?

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

### Test and Documentation

- [x] Tests have been completed.
- [x] Documentation has been added or updated.

### Issue References

A furthering of #116

### Additional Information

N/A