### PR TITLE
feat: refresh access token

### DIFF
--- a/PowerVCF.psm1
+++ b/PowerVCF.psm1
@@ -4564,6 +4564,7 @@ Function checkVCFToken {
             $uri = "https://$sddcManager/v1/tokens/access-token/refresh"
             $response = Invoke-RestMethod -Method PATCH -Uri $uri -Headers $headers -Body $refreshToken
             $Global:accessToken = $response
+            createHeader # Set the Accept and Authorization headers with the new access token.
         }
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 no-inline-html -->

### Summary

After an access token expires, the first cmdlet to run afterwards will fail because the old access token is still being used.

By adding `createHeader` to `checkVcfToken` if a new access token has been requested and received, the cmdlet that first invokes checkVcfToken post-expiry will also work.

**Example - pre-fix**

Pretend that it's more than an hour since `Request-VCFToken` was run and that the access token is now expired.

```powershell
Get-VCFCluster

Error Message:
{
  "errorCode": "Unauthorized", 
  "message": "Authorization Header is missing or not in correct format" 
}

# Re-running this or any other cmdlet will work
# At this point the cmdlet works because createHeader is run at the start of the cmdlet with the fresh access token from $global:accessToken

Get-VCFCluster
```

### Type

- [x] Bugfix
- [ ] Enhancement or Feature
- [ ] Code Style or Formatting
- [ ] Documentation
- [ ] Refactoring
- [ ] Chore
- [ ] Other
        Please describe:

### Breaking Changes?

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

### Test and Documentation

N/A

### Issue References

N/A

### Additional Information

N/A